### PR TITLE
Add filter to make it possible to choose own way to fetch attribute

### DIFF
--- a/Trustpilot/helper.php
+++ b/Trustpilot/helper.php
@@ -252,6 +252,7 @@ function trustpilot_get_inventory_attribute($attr, $product, $useDbAttribute = t
             return $value ? $value : '';
         default:
             $value = $product->get_attribute($attr_field);
+            $value = apply_filters( 'trustpilot_inventory_attribute_value', $value, $attr_field, $product );
             return $value ? $value : '';
     }
 }


### PR DESCRIPTION
Add filter to make it possible to choose how attribute should be fetched.
This makes the plugin much more flexible.

For example: If you want GTIN on products right now you need to assign GTIN as a product attribute to the product.
This works OK, but makes you very limited.
If you have variable products you need to assign the attributes as variations to each variation of the product. This creates problems if you want to hide the GTIN attribute in the frontend as the attributes will be shown as dropdowns at the font-end. 

Other cases could be if you already have a GTIN field. Then you probably not want to add GTIN as attribut instead of just use the existing field.

Example how you can easily can get GTIN from the post meta table with help of the added filter and a short code snippet:
```
add_filter( 'trustpilot_inventory_attribute_value', 'get_trustpilot_gtin_value', 10, 3 );

function get_trustpilot_gtin_value( $value, $attr_field, $product ) {
	if ( 'gtin' !== $attr_field ) {
		return $value;
	}
	
	return get_post_meta( $product->get_id(), 'GTIN', true );
}
```

The same could be done with other values, like MPN, and the developers can choose how to receive the value. 
This would make the plugin much more customizable.